### PR TITLE
Feature/6/api-caching-optimization :  axios 요청 래퍼함수 작성

### DIFF
--- a/src/axiosCached.js
+++ b/src/axiosCached.js
@@ -1,0 +1,25 @@
+import * as axiosReal from 'axios';
+
+const axios = {
+  get: async (...args) => {
+    // localStorage를 참조하여 동일한 요청이 있는지 확인합니다.
+    // console.log('axios intercepted', args);
+    const [url, options] = args;
+    const request = { url, options };
+    const cachedResponse = localStorage.getItem(JSON.stringify(request));
+    if (cachedResponse) {
+      return JSON.parse(cachedResponse);
+    }
+
+    /* 캐시에 없는 요청이면 debounce 패턴을 적용하여 요청합니다. */
+    //TODO
+    //const response = await axiosReal(...args);
+
+    //요청을 마치면 해당 요청을 캐시에 저장합니다.
+    //TODO
+
+    return await axiosReal.get(...args);
+  },
+};
+
+export default axios;

--- a/src/utilities/axiosCached.js
+++ b/src/utilities/axiosCached.js
@@ -11,14 +11,12 @@ const axios = {
       return JSON.parse(cachedResponse);
     }
 
-    /* 캐시에 없는 요청이면 debounce 패턴을 적용하여 요청합니다. */
-    //TODO
-    //const response = await axiosReal(...args);
+    // 캐싱된 응답이 없다면 원본 요청을 실행합니다
+    const response = await axiosReal.get(...args);
 
-    //요청을 마치면 해당 요청을 캐시에 저장합니다.
-    //TODO
-
-    return await axiosReal.get(...args);
+    // 캐싱된 응답을 localStorage에 저장합니다.
+    localStorage.setItem(JSON.stringify(request), JSON.stringify(response));
+    return response;
   },
 };
 


### PR DESCRIPTION
## 목적
axios Wrapper를 작성하여 캐싱과 최적화 달성

## 상세 내용
- axiosCached.js 작성
  ```
    - axios 메소드를 감싸는 wrapper 메소드 생성
    - localStorage와 내용 비교 이미 요청했던 내용이면 캐시에서 값을 돌려줌
    - 그렇지 않은 경우 debounce pattern을 적용하여 동일한 API에 대한 요청은 지연하여 리턴
  ```

## 작업
- [x] axiosCached.js 작성
- [ ] index.js 수정
- [x] 작동여부 테스트
- [x] axios 대신에 ./utilities/axiosCached를 불러와서 작업해 주시면 되겠습니다.

This closes #6 