### PR TITLE
:lipstick: Add keyboard selected UI styling

### DIFF
--- a/src/component/RecommendArea/Recommend.jsx
+++ b/src/component/RecommendArea/Recommend.jsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import SearchIcon from '../../assets/icon_search.svg';
 
-const Recommend = ({ content }) => {
+const Recommend = ({ content, selected }) => {
   return (
-    <RecommendStyled>
+    <RecommendStyled selected={selected}>
       <SearchIcon />
       {content}
     </RecommendStyled>
@@ -14,16 +14,19 @@ const Recommend = ({ content }) => {
 
 Recommend.propTypes = {
   content: PropTypes.string,
+  selected: PropTypes.bool,
 };
 
 const RecommendStyled = styled.li`
+  display: flex;
+  align-items: center;
+  padding-left: 8px;
+  line-height: 2.6;
+  background-color: ${({ selected }) => (selected ? `#efefef` : 'inherit')};
+  cursor: pointer;
   svg {
     margin-right: 12px;
   }
-  display: flex;
-  align-items: center;
-  line-height: 2.6;
-  cursor: pointer;
 `;
 
 export default Recommend;


### PR DESCRIPTION
resolved: #15 

- 추천 검색어 리스트에서 키보드 이동을 통해 선택된 검색어 스타일이 변경되는 기능을 구현하기 위해서, 
- selected props 값이 true인 Recommend 스타일 컴포넌트에 
`selected === true` 인 경우의 스타일 속성을 추가했습니다. 
- 배경색을 설정하고, 패딩값 등을 보기 좋게 조절해주었습니다.  

- 로컬 개발서버에서 테스트 완료했습니다. 

- **Recommend 컴포넌트의 selected props를 통해 키보드 검색어 이동 기능과 연동해주시면 됩니다.** 